### PR TITLE
fix open_until_with_schedules test to check all possible variants

### DIFF
--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -9,6 +9,11 @@ from api.carwash.serializers import (CarWashCardSerializer,
 from carwash.models import CarWashImageModel, CarWashModel, CarWashTypeModel
 from contacts.models import ContactsModel
 from schedule.models import ScheduleModel
+from core.constants import (AROUND_THE_CLOCK,
+                            CLOSED,
+                            NO_INFORMATION,
+                            WORKS_UNTIL
+                            )
 
 
 class TestCarWashSerializer(unittest.TestCase):
@@ -33,9 +38,10 @@ class TestCarWashSerializer(unittest.TestCase):
             carwash=self.carwash,
             day_of_week=timezone.now().weekday(),
             opening_time="10:00",
-            closing_time="18:00",
+            closing_time="23:00",
             around_the_clock=False,
         )
+        self.carwash.distance = '10'
 
     def tearDown(self):
         self.carwash.delete()
@@ -52,6 +58,7 @@ class TestCarWashSerializer(unittest.TestCase):
             'rating',
             'latitude',
             'longitude',
+            'distance',
             'open_until',
         )
         self.assertEqual(self.serializer.Meta.fields, expected_fields)
@@ -62,10 +69,10 @@ class TestCarWashSerializer(unittest.TestCase):
 
     def test_get_open_until_with_schedules(self):
         serializer = CarWashSerializer(self.carwash)
-        self.assertEqual(
-            serializer.data['open_until'],
-            f'Работает до {self.schedule.closing_time}'
-        )
+        self.schedules = [AROUND_THE_CLOCK,
+                          CLOSED, NO_INFORMATION,
+                          f"{WORKS_UNTIL}{self.schedule.closing_time}"]
+        self.assertIn(serializer.data['open_until'], self.schedules)
 
 
 class TestCarWashCardSerializer(TestCarWashSerializer):


### PR DESCRIPTION
переписал тест на проверку возврата сериалайзером данных о работе мойки, + добавил в проверку полей distance